### PR TITLE
Fix 404 links and add Tops API in API overview

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -20,13 +20,12 @@ Web3 API is a suite of **REST** and **Stream** APIs that simplify your web3 deve
     <Card title="Token API" href="/api-reference/web3-api/token" />
     <Card title="Balance API" href="/api-reference/web3-api/balance" />
     <Card title="Domain API" href="/api-reference/web3-api/domain" />
-    <Card title="Inscription API" href="/api-reference/web3-api/inscription" />
 </CardGroup>
 
 
 ## Advanced API Suite
 
 <CardGroup cols={2}>
-    <Card title="Webhook API" href="/api-reference/webhook-api" />
     <Card title="SQL API" href="/api-reference/sql-api" />
+    <Card title="Tops API" href="/api-reference/tops-api/tool/list-trending-topics" />
 </CardGroup>


### PR DESCRIPTION
## Summary
- Remove broken links: Inscription API (`/api-reference/web3-api/inscription`) and Webhook API (`/api-reference/webhook-api`)
- Add Tops API card to the Advanced API Suite section

## Test plan
- [ ] Verify removed links no longer appear on the overview page
- [ ] Verify Tops API card links to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)