### PR TITLE
Add redirect alias for litepaper page

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -697,6 +697,12 @@
       ]
     }
   ],
+  "redirects": [
+    {
+      "source": "/introduction/litepaper",
+      "destination": "/network/introduction/litepaper"
+    }
+  ],
   "footerSocials": {
     "x": "https://twitter.com/chainbaseHQ",
     "discord": "https://chainbase.com/discord",


### PR DESCRIPTION
## Summary
- Add a redirect so `/introduction/litepaper` also opens the litepaper page at `/network/introduction/litepaper`
- After the docs restructure moved pages under `/network/`, this ensures the old path still works

## Test plan
- [x] Local `mintlify dev` verified: `/introduction/litepaper` returns 307 redirect
- [x] `/network/introduction/litepaper` returns 200 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)